### PR TITLE
Added basic move ordering of captures

### DIFF
--- a/movepick.c
+++ b/movepick.c
@@ -31,4 +31,21 @@ void pick_move(MoveList *moves, int start_index)
 
 void score_moves(MoveList *moves, const GameState *pos, Move tt_move, int ply)
 {
+    for (int i = 0; i < moves->next_open; i++) {
+        // Score captures
+        if (moves->move[i] & IS_CAPTURE) {
+            int piece_offset = 6 * pos->turn;
+            moves->score[i] = MVV_LVA_TABLE[GET_MOVE_PIECE(moves->move[i]) - piece_offset][
+                                  GET_MOVE_CAPTURED(moves->move[i])] + KILLER_ONE;
+
+            // Give bad score to results with negative SEE
+            if (see(pos, GET_MOVE_DST(moves->move[i])) < -100) {
+                moves->score[i] -= KILLER_ONE;
+            }
+        }
+        // Score quiet moves
+        else {
+            moves->score[i] = HISTORY_SCORE_MAX;
+        }
+    }
 }

--- a/search.c
+++ b/search.c
@@ -181,7 +181,6 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info)
         }
 
         if (info->stopped) {
-            info->pv_table_length[ply] = 0;
             return 0;
         }
     }


### PR DESCRIPTION
```
Elo   | 295.34 +- 49.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 3.12 (-2.94, 2.94) [0.00, 5.00]
Games | N: 382 W: 305 L: 41 D: 36
Penta | [3, 5, 31, 29, 123]
```
http://rebeltx.ddns.net/test/5/

bench: 7723551