### PR TITLE
Added history score

### DIFF
--- a/movepick.c
+++ b/movepick.c
@@ -53,7 +53,7 @@ void score_moves(MoveList *moves, const GameState *pos, Move tt_move, int ply)
         }
         // Score quiet moves
         else {
-            moves->score[i] = HISTORY_SCORE_MAX;
+            moves->score[i] = get_history(pos, m);
         }
     }
 }

--- a/search.c
+++ b/search.c
@@ -211,6 +211,19 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info)
         return in_check ? -MATE_SCORE + ply : 0;
     }
 
+    // Update history score if not a capture and beta cutoff
+    if (best_move && !is_noisy(best_move)) {
+        //push_killer_move(best_move, ply);
+
+        int bonus = score_history(pos, best_move, depth);
+        int penalty = -bonus;
+        update_history(pos, best_move, bonus);
+
+        for (int i = 0; i < fail_low_quiets.next_open; i++) {
+            update_history(pos, fail_low_quiets.move[i], penalty);
+        }
+    }
+
     save_tt(pos, best_move, best_score, tt_flag, depth, ply);
     return best_score;
 }


### PR DESCRIPTION
```
Elo   | 58.01 +- 16.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1076 W: 476 L: 298 D: 302
Penta | [32, 80, 191, 148, 87]
```
http://rebeltx.ddns.net/test/10/

bench: 5203230