### PR TITLE
Added history penalty

### DIFF
--- a/search.c
+++ b/search.c
@@ -152,6 +152,7 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info)
         if (!make_move(pos, &new_pos, current))
             continue;
 
+        bool noisy = is_noisy(current);
         move_count++;
         info->ply++;
 
@@ -198,6 +199,10 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info)
                 }
                 tt_flag = TT_EXACT;
             }
+        }
+
+        if (current != best_move && !noisy) {
+            fail_low_quiets.move[fail_low_quiets.next_open++] = current;
         }
 
         if (info->stopped) {


### PR DESCRIPTION
```
Elo   | 11.98 +- 7.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5398 W: 2007 L: 1821 D: 1570
Penta | [231, 490, 1121, 576, 281]
```
http://rebeltx.ddns.net/test/11/

bench: 5270740