### PR TITLE
Added late move reductions

### DIFF
--- a/bench.h
+++ b/bench.h
@@ -1,7 +1,7 @@
 #ifndef CHESSENGINE_BENCH_H
 #define CHESSENGINE_BENCH_H
 
-#define BENCH_DEPTH 6
+#define BENCH_DEPTH 8
 void run_benchmark();
 
 #endif

--- a/search.c
+++ b/search.c
@@ -168,7 +168,12 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info)
             score = -search(-beta, -alpha, new_depth, &new_pos, info);
         }
         else {
-            score = -search(-alpha - 1, -alpha, new_depth, &new_pos, info);
+            int r = calculate_reduction(current, move_count, depth, pv_node);
+            int reduced = CLAMP(new_depth - r, 0, new_depth);
+            score = -search(-alpha - 1, -alpha, reduced, &new_pos, info);
+            if (score > alpha && reduced < new_depth) {
+                score = -search(-alpha - 1, -alpha, new_depth, &new_pos, info);
+            }
             if (score > alpha && score < beta) {
                 score = -search(-beta, -alpha, new_depth, &new_pos, info);
             }


### PR DESCRIPTION
```Elo   | 226.45 +- 31.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 398 W: 262 L: 34 D: 102
Penta | [0, 6, 37, 78, 78]
```
http://rebeltx.ddns.net/test/12/

bench: 1192514