### PR TITLE
Lmr lookup table

### DIFF
--- a/main.c
+++ b/main.c
@@ -26,6 +26,7 @@ int main(int argc, char *argv[])
     init_attacks();
     init_tt(&GLOBAL_TT);
     init_et(&GLOBAL_ET);
+    init_lmr_table();
 
     if (argc > 1 && strcmp(argv[1], "bench") == 0) {
         run_benchmark();

--- a/search.c
+++ b/search.c
@@ -65,9 +65,18 @@ inline bool is_repetition(const GameState *pos)
     return false; // Detects a single rep
 }
 
+void init_lmr_table()
+{
+    for (int depth = 0; depth < MAX_PLY; depth++) {
+        for (int move_count = 0; move_count < MAX_MOVES; move_count++) {
+            lmr_table[depth][move_count] = 0.77 + log(move_count) * log(depth) / 2.36;
+        }
+    }
+}
+
 inline int calculate_reduction(Move m, int move_count, int depth, bool pv_node)
 {
-    int r = 0.77 + log(move_count) * log(depth) / 2.36;
+    int r = lmr_table[depth][move_count];
     if (move_count <= FULL_DEPTH_MOVES || depth <= 2)
         r = 0;
     r += !pv_node;

--- a/search.c
+++ b/search.c
@@ -78,7 +78,7 @@ void init_lmr_table()
 
 int calculate_reduction(Move m, int move_count, int depth, bool pv_node)
 {
-    // Prevent out of bounds error when approachine max ply
+    // Prevent out of bounds error when approaching max ply
     if (depth >= MAX_PLY)
         depth = MAX_PLY - 1;
     int r = lmr_table[depth][move_count];

--- a/search.c
+++ b/search.c
@@ -11,6 +11,8 @@
 #include "tt.h"
 #include "util.h"
 
+static int lmr_table[MAX_PLY][MAX_MOVES];
+
 void report_search_info(SearchInfo *root_info, int score)
 {
     if (!root_info)
@@ -74,8 +76,11 @@ void init_lmr_table()
     }
 }
 
-inline int calculate_reduction(Move m, int move_count, int depth, bool pv_node)
+int calculate_reduction(Move m, int move_count, int depth, bool pv_node)
 {
+    // Prevent out of bounds error when approachine max ply
+    if (depth >= MAX_PLY)
+        depth = MAX_PLY - 1;
     int r = lmr_table[depth][move_count];
     if (move_count <= FULL_DEPTH_MOVES || depth <= 2)
         r = 0;

--- a/search.h
+++ b/search.h
@@ -50,8 +50,6 @@ static const int MVV_LVA_TABLE[6][12] =
     {100, 200, 300, 400, 500, 0, 100, 200, 300, 400, 500, 0}
 };
 
-int lmr_table[MAX_PLY][MAX_MOVES];
-
 void init_lmr_table();
 int qsearch(int alpha, int beta, GameState *pos, SearchInfo *info);
 void search_root(GameState *pos, SearchInfo *search_info);

--- a/search.h
+++ b/search.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 #include "move.h"
+#include "movelist.h"
 #include "position.h"
 
 #define MAX_PLY 128
@@ -49,6 +50,9 @@ static const int MVV_LVA_TABLE[6][12] =
     {100, 200, 300, 400, 500, 0, 100, 200, 300, 400, 500, 0}
 };
 
+int lmr_table[MAX_PLY][MAX_MOVES];
+
+void init_lmr_table();
 int qsearch(int alpha, int beta, GameState *pos, SearchInfo *info);
 void search_root(GameState *pos, SearchInfo *search_info);
 void read_input(SearchInfo *info);


### PR DESCRIPTION
```
Elo   | 9.46 +- 5.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5842 W: 1529 L: 1370 D: 2943
Penta | [97, 693, 1229, 758, 144]
```

http://rebeltx.ddns.net/test/26/