### PR TITLE
Exits early from qsearch when out of time

### DIFF
--- a/search.c
+++ b/search.c
@@ -207,6 +207,10 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info)
         info->ply--;
         repetition_index--;
 
+        if (info->stopped) {
+            return 0;
+        }
+
         if (score > best_score) {
             best_score = score;
 
@@ -232,10 +236,6 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info)
 
         if (current != best_move && !noisy) {
             fail_low_quiets.move[fail_low_quiets.next_open++] = current;
-        }
-
-        if (info->stopped) {
-            return 0;
         }
     }
 
@@ -321,6 +321,10 @@ int qsearch(int alpha, int beta, GameState *pos, SearchInfo *info)
         info->ply++;
         int score = -qsearch(-beta, -alpha, &new_pos, info);
         info->ply--;
+
+        if (info->stopped) {
+            return 0;
+        }
 
         if (score > best_score) {
             best_score = score;


### PR DESCRIPTION
```

Elo   | 20.87 +- 9.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2434 W: 694 L: 548 D: 1192
Penta | [44, 250, 505, 352, 66]
```
http://rebeltx.ddns.net/test/31/