### PR TITLE
NMP reduces more based on depth

### DIFF
--- a/search.c
+++ b/search.c
@@ -168,7 +168,7 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
         // Null Move Pruning
         if (depth >= MIN_NMP_DEPTH && static_eval >= beta && info->move_stack[ply - 1]
             && !only_has_pawns(pos, pos->turn)) {
-            int r = 4;
+            int r = 4 + depth / 4;
 
             // Make the null move
             GameState null_pos;


### PR DESCRIPTION
```
Elo   | 12.61 +- 7.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4712 W: 1445 L: 1274 D: 1993
Penta | [138, 508, 936, 593, 181]
```

https://rebeltx.ddns.net/test/40/