### PR TITLE
SEE pruning

### DIFF
--- a/search.c
+++ b/search.c
@@ -137,12 +137,6 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
             info->pv_table_length[ply] = 0;
             return 0;
         }
-
-        // Mate distance pruning
-        alpha = MAX(alpha, -MATE_SCORE + ply);
-        beta = MIN(beta, MATE_SCORE - ply - 1);
-        if (alpha >= beta)
-            return alpha;
     }
 
     // tt_hit is boolean, if no entry found, move is set to 0

--- a/search.c
+++ b/search.c
@@ -208,6 +208,13 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
             continue;
 
         bool noisy = is_noisy(current);
+        if (best_score > -MATE_SCORE && !in_check) {
+            // SEE pruning
+            int see_threshold = noisy ? -75 * depth : -25 * depth;
+            if (see(pos, GET_MOVE_DST(current)) <= see_threshold)
+                continue;
+        }
+
         move_count++;
         info->ply++;
 

--- a/search.c
+++ b/search.c
@@ -137,6 +137,12 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
             info->pv_table_length[ply] = 0;
             return 0;
         }
+
+        // Mate distance pruning
+        alpha = MAX(alpha, -MATE_SCORE + ply);
+        beta = MIN(beta, MATE_SCORE - ply - 1);
+        if (alpha >= beta)
+            return alpha;
     }
 
     // tt_hit is boolean, if no entry found, move is set to 0


### PR DESCRIPTION
```
Elo   | 5.98 +- 4.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11920 W: 3529 L: 3324 D: 5067
Penta | [344, 1396, 2326, 1499, 395]
```

https://rebeltx.ddns.net/test/42/