### PR TITLE
Added forward futility pruning

### DIFF
--- a/search.c
+++ b/search.c
@@ -213,6 +213,11 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
 
         bool noisy = is_noisy(current);
         if (best_score > -MATE_SCORE && !in_check) {
+            // Futility Pruning
+            if (!noisy && depth <= 8 && abs(alpha) < MATE_SCORE && static_eval + depth * 125 <= alpha) {
+                continue;
+            }
+
             // SEE pruning
             int see_threshold = noisy ? -75 * depth : -25 * depth;
             if (see(pos, GET_MOVE_DST(current)) <= see_threshold)


### PR DESCRIPTION
```
Elo   | 21.16 +- 9.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2548 W: 805 L: 650 D: 1093
Penta | [58, 257, 523, 344, 92]
```
https://rebeltx.ddns.net/test/59/

bench: 7787005