### PR TITLE
Mate distance pruning

### DIFF
--- a/search.c
+++ b/search.c
@@ -135,6 +135,12 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
             info->pv_table_length[ply] = 0;
             return 0;
         }
+
+        // Mate distance pruning
+        alpha = MAX(alpha, -MATE_SCORE + ply);
+        beta = MIN(beta, MATE_SCORE - ply - 1);
+        if (alpha >= beta)
+            return alpha;
     }
 
     // Enter qsearch


### PR DESCRIPTION
```
Elo   | 1.60 +- 4.05 (95%)
SPRT  | 1.0+0.01s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 15642 W: 4847 L: 4775 D: 6020
Penta | [581, 1924, 2782, 1910, 624]
```

https://rebeltx.ddns.net/test/65/