### PR TITLE
reduce less when improving

### DIFF
--- a/search.c
+++ b/search.c
@@ -272,6 +272,7 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
             int r = calculate_reduction(current, move_count, depth);
             r += !pv_node;
             r -= gives_check;
+            r -= improving;
             int reduced = CLAMP(new_depth - r, 0, new_depth);
             score = -search(-alpha - 1, -alpha, reduced, &new_pos, info, true);
             if (score > alpha && reduced < new_depth) {


### PR DESCRIPTION
```
Elo   | 23.35 +- 9.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2340 W: 747 L: 590 D: 1003
Penta | [56, 244, 449, 329, 92]
```
https://rebeltx.ddns.net/test/96/

bench: 10480560