### PR TITLE
Lmp lookup table

### DIFF
--- a/main.c
+++ b/main.c
@@ -27,6 +27,7 @@ int main(int argc, char *argv[])
     init_tt();
     init_et();
     init_lmr_table();
+    init_lmp_table();
 
     if (argc > 1 && strcmp(argv[1], "bench") == 0) {
         run_benchmark();

--- a/search.c
+++ b/search.c
@@ -13,6 +13,7 @@
 #include "util.h"
 
 static int lmr_table[MAX_PLY][MAX_MOVES];
+static int lmp_table[16][2];
 
 void report_search_info(SearchInfo *root_info, int score)
 {
@@ -73,6 +74,15 @@ void init_lmr_table()
     for (int depth = 0; depth < MAX_PLY; depth++) {
         for (int move_count = 0; move_count < MAX_MOVES; move_count++) {
             lmr_table[depth][move_count] = 0.77 + log(move_count) * log(depth) / 2.36;
+        }
+    }
+}
+
+void init_lmp_table()
+{
+    for (int depth = 0; depth < 16; depth++) {
+        for (int imp = 0; imp < 2; imp++) {
+            lmp_table[depth][imp] = (MIN_LMP_MOVES + depth * depth) / (2 - imp);
         }
     }
 }
@@ -245,7 +255,7 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
             }
 
             // Late Move Pruning
-            if (!noisy && move_count >= (3 + depth * depth) / (2 - improving)){
+            if (!noisy && move_count >= lmp_table[MIN(depth, 15)][improving]){
                 continue;
             }
 

--- a/search.c
+++ b/search.c
@@ -80,6 +80,7 @@ void init_lmr_table()
 
 void init_lmp_table()
 {
+    // Capped at 15 depth since cannot have more than 256 possible legal moves
     for (int depth = 0; depth < 16; depth++) {
         for (int imp = 0; imp < 2; imp++) {
             lmp_table[depth][imp] = (MIN_LMP_MOVES + depth * depth) / (2 - imp);

--- a/search.h
+++ b/search.h
@@ -13,6 +13,7 @@
 #define INITIAL_ASP_WINDOW 30
 #define MIN_LMR_MOVES 3
 #define MIN_LMR_DEPTH 2
+#define MIN_LMP_MOVES 3
 #define MIN_NMP_DEPTH 4
 #define MIN_IIR_DEPTH 3
 
@@ -56,6 +57,7 @@ static const int MVV_LVA_TABLE[6][12] =
 };
 
 void init_lmr_table();
+void init_lmp_table();
 int qsearch(int alpha, int beta, GameState *pos, SearchInfo *info, bool pv_node);
 void search_root(GameState *pos, SearchInfo *search_info);
 void read_input(SearchInfo *info);


### PR DESCRIPTION
```
Elo   | -0.10 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 30586 W: 7633 L: 7642 D: 15311
Penta | [557, 3700, 6766, 3735, 535]
```
https://rebeltx.ddns.net/test/108/

bench: 10669358