### PR TITLE
Rep detection

### DIFF
--- a/search.c
+++ b/search.c
@@ -153,13 +153,19 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
         if (in_check)
             depth++;
 
-        // Search for draws and repetitions
-        // Don't need to search for repetition if halfMoveClock is low
-        if ((pos->half_move_clock > 4 && is_repetition(pos)) || pos->half_move_clock >= 100 ||
-            insufficient_material(pos)) {
-            // Cut the pv line if this is a draw
+        // 50mr and insufficient material
+        if (pos->half_move_clock >= 100 || insufficient_material(pos)) {
             info->pv_table_length[ply] = 0;
             return 0;
+        }        
+
+        // Don't need to search for repetition if halfMoveClock is low
+        if (alpha < 0 && is_repetition(pos)) {
+            alpha = 0;
+            if (alpha >= beta) {
+                info->pv_table_length[ply] = 0;
+                return 0;
+            }
         }
 
         // Mate distance pruning
@@ -374,6 +380,12 @@ int qsearch(int alpha, int beta, GameState *pos, SearchInfo *info, bool pv_node)
     // Search has exceeded max depth, return static eval
     if (ply >= MAX_PLY) {
         return evaluation(pos);
+    }
+
+    if (alpha < 0 && is_repetition(pos)) {
+        alpha = 0;
+        if (alpha >= beta)
+            return alpha;
     }
 
     // tt_hit is boolean, if no entry found, move is set to 0

--- a/search.c
+++ b/search.c
@@ -160,8 +160,7 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
         }        
 
         // Don't need to search for repetition if halfMoveClock is low
-        if (alpha < 0 && pos->half_move_clock > 4 && is_repetition(pos)) {
-            alpha = 0;
+        if (pos->half_move_clock > 4 && is_repetition(pos)) {
             if (alpha >= beta) {
                 info->pv_table_length[ply] = 0;
                 return 0;

--- a/search.c
+++ b/search.c
@@ -381,7 +381,7 @@ int qsearch(int alpha, int beta, GameState *pos, SearchInfo *info, bool pv_node)
         return evaluation(pos);
     }
 
-    if (pos->half_move_clock > 4 && alpha < 0 && is_repetition(pos)) {
+    if (pos->half_move_clock > 4 && is_repetition(pos)) {
         alpha = 0;
         if (alpha >= beta)
             return alpha;

--- a/search.c
+++ b/search.c
@@ -161,10 +161,8 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
 
         // Don't need to search for repetition if halfMoveClock is low
         if (pos->half_move_clock > 4 && is_repetition(pos)) {
-            if (alpha >= beta) {
-                info->pv_table_length[ply] = 0;
-                return 0;
-            }
+            info->pv_table_length[ply] = 0;
+            return 0;
         }
 
         // Mate distance pruning
@@ -381,10 +379,16 @@ int qsearch(int alpha, int beta, GameState *pos, SearchInfo *info, bool pv_node)
         return evaluation(pos);
     }
 
+    // 50mr and insufficient material
+    if (pos->half_move_clock >= 100 || insufficient_material(pos)) {
+        info->pv_table_length[ply] = 0;
+        return 0;
+    }        
+
+    // Don't need to search for repetition if halfMoveClock is low
     if (pos->half_move_clock > 4 && is_repetition(pos)) {
-        alpha = 0;
-        if (alpha >= beta)
-            return alpha;
+        info->pv_table_length[ply] = 0;
+        return 0;
     }
 
     // tt_hit is boolean, if no entry found, move is set to 0

--- a/search.c
+++ b/search.c
@@ -160,7 +160,7 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
         }        
 
         // Don't need to search for repetition if halfMoveClock is low
-        if (alpha < 0 && is_repetition(pos)) {
+        if (alpha < 0 && pos->half_move_clock > 4 && is_repetition(pos)) {
             alpha = 0;
             if (alpha >= beta) {
                 info->pv_table_length[ply] = 0;
@@ -382,7 +382,7 @@ int qsearch(int alpha, int beta, GameState *pos, SearchInfo *info, bool pv_node)
         return evaluation(pos);
     }
 
-    if (alpha < 0 && is_repetition(pos)) {
+    if (pos->half_move_clock > 4 && alpha < 0 && is_repetition(pos)) {
         alpha = 0;
         if (alpha >= beta)
             return alpha;


### PR DESCRIPTION
```
Elo   | 0.68 +- 2.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 19884 W: 4919 L: 4880 D: 10085
Penta | [308, 2390, 4497, 2449, 298]
```
https://rebeltx.ddns.net/test/115/

bench: 10587120