### PR TITLE
tt entry now uses i16 for score to save bits

### DIFF
--- a/bitboard.h
+++ b/bitboard.h
@@ -17,11 +17,16 @@
 (byte & 0x02 ? '1' : '0'), \
 (byte & 0x01 ? '1' : '0')
 
+typedef unsigned __int128 u128;
 typedef uint64_t u64;
 typedef uint32_t u32;
 typedef uint16_t u16;
 typedef uint8_t u8;
-typedef unsigned __int128 u128;
+
+typedef int64_t i64;
+typedef int32_t i32;
+typedef int16_t i16;
+typedef int8_t i8;
 
 enum {
     P, N, B, R, Q, K, p, n, b, r, q, k, NO_PIECE

--- a/tt.c
+++ b/tt.c
@@ -65,7 +65,7 @@ bool probe_tt(const GameState *pos, TTEntry *dst, int ply)
             score += ply;
         }
 
-        dst->score = score;
+        dst->score = (i16) score;
         dst->depth = entry.depth;
         dst->move = entry.move;
         dst->flag = entry.flag;
@@ -99,6 +99,6 @@ void save_tt(const GameState *pos, Move move, int score, int flag, int depth, in
 
     transposition_table.hash_table[i].key = packed_key;
     transposition_table.hash_table[i].flag = flag;
-    transposition_table.hash_table[i].score = score;
-    transposition_table.hash_table[i].depth = (unsigned char) depth;
+    transposition_table.hash_table[i].score = (i16) score;
+    transposition_table.hash_table[i].depth = depth;
 }

--- a/tt.h
+++ b/tt.h
@@ -11,15 +11,15 @@
 
 typedef struct ttEntry {
     int key;
-    unsigned char depth;
-    unsigned char flag;
     Move move;
-    int score;
+    i16 score;
+    u8 depth;
+    u8 flag;
 } TTEntry;
 
 typedef struct tt {
     TTEntry *hash_table;
-    int num_entries;
+    u32 num_entries;
     int new_write;
     int over_write;
     int hit;


### PR DESCRIPTION
```
Elo   | -0.29 +- 2.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 34198 W: 9870 L: 9899 D: 14429
Penta | [1111, 4059, 6773, 4060, 1096]
```
https://rebeltx.ddns.net/test/143/

bench: 28268123