### PR TITLE
Use static in search

### DIFF
--- a/search.c
+++ b/search.c
@@ -201,7 +201,12 @@ int search(int alpha, int beta, int depth, GameState *pos, SearchInfo *info, boo
         static_eval = -INF;
     }
     else {
-        static_eval_raw = evaluation(pos);
+        if (tt_hit && tt_entry.flag != TT_NONE && tt_entry.static_eval != -INF) {
+            static_eval_raw = tt_entry.static_eval;
+        }
+        else {
+            static_eval_raw = evaluation(pos);
+        }
         static_eval = correct_static_eval(pos, static_eval_raw);
     }
     info->static_eval_stack[ply] = static_eval;
@@ -480,7 +485,7 @@ int qsearch(int alpha, int beta, GameState *pos, SearchInfo *info, bool pv_node)
         return -MATE_SCORE + ply;
     }
 
-    save_tt(pos, best_move, static_eval_raw, best_score, tt_flag, 0, ply);
+    save_tt(pos, best_move, -INF, best_score, tt_flag, 0, ply);
     return best_score;
 }
 

--- a/search.c
+++ b/search.c
@@ -485,7 +485,7 @@ int qsearch(int alpha, int beta, GameState *pos, SearchInfo *info, bool pv_node)
         return -MATE_SCORE + ply;
     }
 
-    save_tt(pos, best_move, -INF, best_score, tt_flag, 0, ply);
+    save_tt(pos, best_move, static_eval_raw, best_score, tt_flag, 0, ply);
     return best_score;
 }
 

--- a/tt.c
+++ b/tt.c
@@ -58,7 +58,7 @@ bool probe_tt(const GameState *pos, TTEntry *dst, int ply)
 
     if (entry.key == packed_key && entry.flag != TT_NONE) {
         // Adjust mate score in TT
-        int score = entry.score;
+        i16 score = entry.score;
         if (score > MAX_MATE_SCORE) {
             score -= ply;
         }
@@ -66,7 +66,8 @@ bool probe_tt(const GameState *pos, TTEntry *dst, int ply)
             score += ply;
         }
 
-        dst->score = (i16) score;
+        dst->static_eval = entry.static_eval;
+        dst->score = score;
         dst->depth = entry.depth;
         dst->move = entry.move;
         dst->flag = entry.flag;


### PR DESCRIPTION
```
Elo   | 2.86 +- 2.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 45388 W: 13261 L: 12888 D: 19239
Penta | [1363, 5331, 9033, 5504, 1463]
```
https://rebeltx.ddns.net/test/156/