### PR TITLE
Eval fix

### DIFF
--- a/evaluation.c
+++ b/evaluation.c
@@ -44,14 +44,16 @@ int material_count(const GameState *pos)
     return (pos->turn == WHITE) ? eval : -eval;
 }
 
-int non_pawn_material(const GameState *pos)
+int material(const GameState *pos)
 {
     int m = 0;
+    m += COUNT_BITS(pos->piece_bitboards[P]) * piece_value[P];
     m += COUNT_BITS(pos->piece_bitboards[N]) * piece_value[N];
     m += COUNT_BITS(pos->piece_bitboards[B]) * piece_value[B];
     m += COUNT_BITS(pos->piece_bitboards[R]) * piece_value[R];
     m += COUNT_BITS(pos->piece_bitboards[Q]) * piece_value[Q];
 
+    m += COUNT_BITS(pos->piece_bitboards[p]) * piece_value[p];
     m += COUNT_BITS(pos->piece_bitboards[n]) * piece_value[n];
     m += COUNT_BITS(pos->piece_bitboards[b]) * piece_value[b];
     m += COUNT_BITS(pos->piece_bitboards[r]) * piece_value[r];
@@ -90,11 +92,10 @@ int nnue_eval(const GameState *pos)
     return evaluate_nnue(pos->turn, pieces, squares);
 }
 
-int evaluation(GameState *pos)
+int evaluation(const GameState *pos)
 {
     int score = 0;
-    int mat_pawns = COUNT_BITS(pos->piece_bitboards[P] | pos->piece_bitboards[p]);
-    int mat = non_pawn_material(pos) + mat_pawns * piece_value[P];
+    int mat = material(pos);
     if (FOUND_NETWORK)
         score = nnue_eval(pos) * (720 + mat / 32) / 1024 + 28;
     else

--- a/evaluation.c
+++ b/evaluation.c
@@ -95,14 +95,11 @@ int nnue_eval(const GameState *pos)
 
 int evaluation(const GameState *pos)
 {
-    int score = 0;
-    int mat = material(pos);
-    if (FOUND_NETWORK)
-        score = nnue_eval(pos) * (720 + mat / 32) / 1024 + 28;
-    else
-        score += material_count(pos);
-
-    return score;
+    if (FOUND_NETWORK) {
+        int mat = material(pos);
+        return nnue_eval(pos) * (720 + mat / 32) / 1024 + 28;
+    }
+    return material_count(pos);
 }
 
 void print_evaluation(int score)

--- a/evaluation.h
+++ b/evaluation.h
@@ -90,7 +90,7 @@ static const int nnue_pieces[12] =
 
 void print_evaluation(int score);
 int nnue_eval(const GameState *pos);
-int evaluation(GameState *pos);
+int evaluation(const GameState *pos);
 int see(const GameState *pos, int square);
 
 #endif


### PR DESCRIPTION
```
Elo   | 1.11 +- 3.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 17552 W: 5072 L: 5016 D: 7464
Penta | [589, 2036, 3461, 2110, 580]
```
https://rebeltx.ddns.net/test/163/

bench: 27833266