### PR TITLE
Castling not considered noisy

### DIFF
--- a/move.c
+++ b/move.c
@@ -45,7 +45,7 @@ unsigned char adjust_castling_rights(const GameState *pos, int src, int dst, int
 bool is_noisy(Move move)
 {
     assert(move != 0);
-    return move & (IS_CAPTURE | IS_PROMOTION | IS_CASTLES);
+    return move & (IS_CAPTURE | IS_PROMOTION);
 }
 
 bool make_move(const GameState *old_pos, GameState *new_pos, Move move)


### PR DESCRIPTION
```
Elo   | 1.86 +- 4.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 14032 W: 4111 L: 4036 D: 5885
Penta | [463, 1615, 2788, 1684, 466]
```
https://rebeltx.ddns.net/test/175/
bench: 27361806